### PR TITLE
use build instead of run dev

### DIFF
--- a/Disaster-Response-Platform/frontend/Dockerfile
+++ b/Disaster-Response-Platform/frontend/Dockerfile
@@ -1,7 +1,14 @@
-FROM node:16.14.0
+FROM node:16-alpine as build
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY package.json .
-COPY package-lock.json .
+
+COPY package.json package-lock.json  ./
 RUN npm install
+
 COPY . .
-CMD npm run dev
+RUN npm run build
+
+EXPOSE 3000
+ENV PORT 3000
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
I changed the docker file of the frontend since `npm run dev` is not a good idea for building a frontend application because it uses lots of CPU and memory on EC machine. Instead, I used `npm run build` and then `npm run start`