### PR TITLE
added returning all recurrent resources for get_resource_by_id

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/need_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/need_controller.py
@@ -27,7 +27,7 @@ def get_need(need_id: str, response:Response):
     try:
         need = need_service.get_need_by_id(need_id)
         response.status_code = HTTPStatus.OK
-        return json.loads(need)
+        return need
     except ValueError as err:
         err_json = create_json_for_error("Need error", str(err))
         response.status_code = HTTPStatus.NOT_FOUND

--- a/Disaster-Response-Platform/backend/Controllers/resource_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/resource_controller.py
@@ -53,7 +53,7 @@ def get_resource(resource_id: str, response: Response):
     try:
         resource = resource_service.get_resource_by_id(resource_id)
         response.status_code = HTTPStatus.OK
-        return json.loads(resource)
+        return resource
     except ValueError as err:
         err_json = create_json_for_error("Resource error", str(err))
         response.status_code = HTTPStatus.NOT_FOUND

--- a/Disaster-Response-Platform/backend/Models/need_model.py
+++ b/Disaster-Response-Platform/backend/Models/need_model.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, validator
-from typing import Dict, Any
+from typing import Dict, Any, List
 from enum import Enum
 import datetime
 from Models.resource_model import Recurrence
@@ -48,3 +48,5 @@ class UrgencyUpdate(BaseModel):
 # class voteUpdate(BaseModel):
 #     vote: int
 
+class NeedList(BaseModel):
+    needs: List[Dict]

--- a/Disaster-Response-Platform/backend/Models/resource_model.py
+++ b/Disaster-Response-Platform/backend/Models/resource_model.py
@@ -57,4 +57,4 @@ class ConditionUpdate(BaseModel):
     condition: ConditionEnum
 
 class ResourceList(BaseModel):
-    resource_list: List[Dict]
+    resources: List[Dict]

--- a/Disaster-Response-Platform/backend/Models/resource_model.py
+++ b/Disaster-Response-Platform/backend/Models/resource_model.py
@@ -56,3 +56,5 @@ class QuantityUpdate(BaseModel):
 class ConditionUpdate(BaseModel):
     condition: ConditionEnum
 
+class ResourceList(BaseModel):
+    resource_list: List[Dict]

--- a/Disaster-Response-Platform/backend/Services/need_service.py
+++ b/Disaster-Response-Platform/backend/Services/need_service.py
@@ -1,4 +1,4 @@
-from Models.need_model import Need
+from Models.need_model import Need, NeedList
 from Database.mongo import MongoDB
 from bson.objectid import ObjectId
 from Services.build_API_returns import *
@@ -53,8 +53,25 @@ def create_need(need: Need) -> str:
     # return str(result.inserted_id)
 
 
-def get_need_by_id(need_id: str) -> list[dict]:
-    return get_needs(need_id)
+def get_need_by_id(need_id: str) -> list[Need]:
+    need_list=[]
+    need = needs_collection.find_one({"_id": ObjectId(need_id)})
+    if not need:
+        raise ValueError("There is no need with this id")
+    #need["x"] = str(need["_id"])
+    recurrence_id = need.get("recurrence_id")
+    if recurrence_id is not None:
+        # Find other needs with the same recurrence_id
+        additional_needs = needs_collection.find({"recurrence_id": recurrence_id})
+        additional_needs = [{**r, "_id": str(r["_id"])} for r in additional_needs]
+
+   
+        need_list.extend(additional_needs)
+    else:
+        need_dict = {**need, "_id": str(need["_id"])}
+        need_list.append(need_dict)
+        #resource_list.append(resource)
+    return NeedList(needs= need_list)
 
 def create_recurrent_needs(need:Need):
 

--- a/Disaster-Response-Platform/backend/Services/resource_service.py
+++ b/Disaster-Response-Platform/backend/Services/resource_service.py
@@ -1,4 +1,4 @@
-from Models.resource_model import Resource, ConditionEnum
+from Models.resource_model import Resource, ConditionEnum, ResourceList
 from Database.mongo import MongoDB
 from bson.objectid import ObjectId
 from pymongo import ASCENDING, DESCENDING
@@ -87,7 +87,7 @@ def get_resource_by_id(resource_id: str) -> list[Resource]:
         resource_dict = {**resource, "_id": str(resource["_id"])}
         resource_list.append(resource_dict)
         #resource_list.append(resource)
-    return resource_list
+    return ResourceList(resource_list= resource_list)
 
 def get_resources(
     resource_id: str = None,

--- a/Disaster-Response-Platform/backend/Services/resource_service.py
+++ b/Disaster-Response-Platform/backend/Services/resource_service.py
@@ -87,7 +87,7 @@ def get_resource_by_id(resource_id: str) -> list[Resource]:
         resource_dict = {**resource, "_id": str(resource["_id"])}
         resource_list.append(resource_dict)
         #resource_list.append(resource)
-    return ResourceList(resource_list= resource_list)
+    return ResourceList(resources= resource_list)
 
 def get_resources(
     resource_id: str = None,


### PR DESCRIPTION
### Changelog
- updated api/resources/{reource_id}  to return a list instead of a single resource to be able to return all recurrences of the same resource.
- updated api/needs/{need_id}  to return a list instead of a single need to be able to return all recurrences of the same need.
### Related screenshots
* Before for the same recurring resource:

   <img width="312" alt="image" src="https://github.com/bounswe/bounswe2023group2/assets/53114791/fb5d10c4-f262-4521-8048-d6add0e43b58">
 
* After my change:

   <img width="348" alt="image" src="https://github.com/bounswe/bounswe2023group2/assets/53114791/7be9b575-bcbd-49b0-9996-c975b58879e9">

#670 