### PR TITLE
BE/bugfix/reset-password-request: Add empty body to post request in html script

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
@@ -132,19 +132,22 @@ async def reset_password_page(request: Request, email: str = Query(None, descrip
                 }}
 
                 if (!is_valid_password(newPassword)) {{
-                    resultMessage.style.display = "block";
+                     document.getElementById("resultMessage").style.display = "block"
                     resultMessage.innerText = "Password is not valid. It must contain at least one digit.";
                     return;
                 }}
 
-                const response = await fetch(`/api/forgot_password/reset?email=`+ email + `&token=` + token + `&new_password=` + newPassword, {{
-                    method: "POST"
+                const response = await fetch(`/api/forgot_password/reset?email=`+ encodeURIcomponent(email) + `&token=` + encodeURIcomponent(token) + `&new_password=` + encodeURIcomponent(newPassword), {{
+                    method: "POST",
+                    body: JSON.stringify({{}})
                 }});
 
                 if (response.status === 200) {{
+                     document.getElementById("resultMessage").style.display = "block"
                     document.getElementById("resultMessage").innerText = "Password reset successful. You can close this tab.";
                     document.getElementById("resultMessage").style.color = "#104569";
                 }} else {{
+                     document.getElementById("resultMessage").style.display = "block"
                     document.getElementById("resultMessage").innerText = "Password reset failed: Invalid token or token expired. Please resend reset request.";
                 }}
             }}

--- a/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
@@ -20,8 +20,9 @@ async def reset_password_page(request: Request, email: str = Query(None, descrip
     # Render the HTML page for resetting the password
 
     # change based on the server url.
-    base_url = "http://3.218.226.215:8000"
-
+    base_url_backend = "http://3.218.226.215:8000"
+    base_url_frontend = "http://3.218.226.215:8000"
+     
     template = f"""
     <!DOCTYPE html>
     <html lang="en">
@@ -144,11 +145,14 @@ async def reset_password_page(request: Request, email: str = Query(None, descrip
 
                 if (response.status === 200) {{
                      document.getElementById("resultMessage").style.display = "block"
-                    document.getElementById("resultMessage").innerText = "Password reset successful. You can close this tab.";
+                    document.getElementById("resultMessage").innerText = "Password reset successful. You are being redirected to the login page unless you close this tab...";
                     document.getElementById("resultMessage").style.color = "#104569";
+                    setTimeout(function() {{
+                        window.location.href = '{base_url_frontend}/login';
+                    }}, 3000);
                 }} else {{
                      document.getElementById("resultMessage").style.display = "block"
-                    document.getElementById("resultMessage").innerText = "Password reset failed: Invalid token or token expired. Please resend reset request.";
+                    document.getElementById("resultMessage").innerText = "Password reset failed: Invalid token or token expired. Please close this tab and resend reset request.";
                 }}
             }}
     </script>


### PR DESCRIPTION
### Overview
This PR fixes a small but crucial bug in the reset password functionality. 
It adds an empty body to the POST request made to the backend endpoint from the HTML page hosted in backend for resetting pasword.

### Modified File
- `Controllers/forgot_password_controller.py`: in the `api/forgot_password/reset_password`endpoint which returns a HTML page for password reset, changed
```
const response = await fetch(`/api/forgot_password/reset?email=`+ encodeURIcomponent(email) + `&token=` + encodeURIcomponent(token) + `&new_password=` + encodeURIcomponent(newPassword), {{
   method: "POST"
 }});
 ```
 to 
```
const response = await fetch(`/api/forgot_password/reset?email=`+ encodeURIcomponent(email) + `&token=` + encodeURIcomponent(token) + `&new_password=` + encodeURIcomponent(newPassword), {{
   method: "POST",
   body: JSON.stringify({{}})
 }});
 ``` 
 
 
               