### PR TITLE
BE/refactor/reset-password-body: Move new_password to body of the request

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/forgot_password_controller.py
@@ -138,9 +138,14 @@ async def reset_password_page(request: Request, email: str = Query(None, descrip
                     return;
                 }}
 
-                const response = await fetch(`/api/forgot_password/reset?email=`+ encodeURIcomponent(email) + `&token=` + encodeURIcomponent(token) + `&new_password=` + encodeURIcomponent(newPassword), {{
+                const data = {{ new_password: newPassword }};
+
+                const response = await fetch(`/api/forgot_password/reset?email=${{encodeURIComponent(email)}}&token=${{encodeURIComponent(token)}}`, {{
                     method: "POST",
-                    body: JSON.stringify({{}})
+                    body: JSON.stringify(data),
+                    headers: {{
+                        'Content-Type': 'application/json'
+                    }}
                 }});
 
                 if (response.status === 200) {{
@@ -162,11 +167,14 @@ async def reset_password_page(request: Request, email: str = Query(None, descrip
     return HTMLResponse(content=template)
 
 @router.post("/reset", status_code=200)
-async def reset_user_password(email: str = Query(None, description="Email associated with the user"),
-                            token: str = Query(None, description="Verification token obtained from email"), 
-                            new_password: str = Query(None, description="New password")):
-                            
+async def reset_user_password(email: str = Query(..., description="Email associated with the user"),
+                             token: str = Query(..., description="Verification token obtained from email"),
+                             new_password_data: dict = Body(..., description="New password data")):
+    
+    new_password = new_password_data.get('new_password')
+
     if reset_password(email, token, new_password):
         return {"message": "Password reset successful."}
     else:
         raise HTTPException(status_code=400, detail="Invalid token or token expired")
+

--- a/Disaster-Response-Platform/backend/Controllers/need_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/need_controller.py
@@ -44,7 +44,7 @@ def get_all_needs(
     y: float = Query(None, description="Y coordinate for distance calculation"),
     distance_max: float = Query(None, description="Maximum distance for filtering"),
     sort_by: str = Query('created_at', description="Field to sort by"),
-    order: Optional[str] = Query('asc', description="Sort order")
+    order: Optional[str] = Query('desc', description="Sort order")
 ):
 
     if types:

--- a/Disaster-Response-Platform/backend/Controllers/resource_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/resource_controller.py
@@ -70,7 +70,7 @@ def get_all_resources(
     y: float = Query(None, description="Y coordinate for distance calculation"),
     distance_max: float = Query(None, description="Maximum distance for filtering"),
     sort_by: str = Query('created_at', description="Field to sort by"),
-    order: Optional[str] = Query('asc', description="Sort order")
+    order: Optional[str] = Query('desc', description="Sort order")
 ):
     if types:
         types_list = types[0].split(',')

--- a/Disaster-Response-Platform/backend/Services/forgot_password_service.py
+++ b/Disaster-Response-Platform/backend/Services/forgot_password_service.py
@@ -74,7 +74,7 @@ def send_reset_password_email(email):
             <p>Hello,</p>
             <p>To reset your password, please click the following link:</p>
             <p><a href="{reset_link}" style="color:#007FFF;">Reset Password</a></p>
-            <p>This link will expire in 10 minutes.</p>
+            <p>This link will expire in 10 minutes. If you are unable to use the provided link, please use your reset password token manually: <strong style='color:#007FFF;'>{token}</strong></p>
             <p>If you did not request a password reset, please ignore this email.</p>
             <p>Thank you for using our service.</p>
             <p>Sincerely,<br>


### PR DESCRIPTION
### Overview

This PR modifies the reset password process, sending the new_password in the body of the POST request instead of query.

### Modified Files:
- `Controllers/forgot_password_controller.py`: Accept new_password from body instead of query. Update sending form request in HTML script.
- `Services/forgot_password_service.py`: Include password reset token in the mail for manual usage.