### PR TITLE
Be/feature/feedback-status-check

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
@@ -46,9 +46,11 @@ def set_downvote(voteUpdate: VoteUpdate, response: Response, current_user: str =
         return json.loads(err_json)
     
 @router.get("/check", status_code=200)
-def check(voteUpdate: VoteUpdate, current_user: str = Depends(authentication_service.get_current_username)):
+def check(entityType: str = Query(None, description="Entity type (needs, resources, actions, events)"),
+            entityID: str = Query(None, description="ID of the entity"), 
+            current_user: str = Depends(authentication_service.get_current_username)):
     try:
-        response = feedback_service.check_feeedback(voteUpdate.entityType, voteUpdate.entityID, current_user)
+        response = feedback_service.check_feeedback(entityType, entityID, current_user)
         return {"message": response}
     except ValueError as err:
         raise HTTPException(status_code = 500, detail="An error occured while checking the user feedback")

--- a/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 
-from fastapi import APIRouter, HTTPException, Response, Depend, Query
+from fastapi import APIRouter, HTTPException, Response, Depends, Query
 from Models.feedback_model import Feedback, VoteUpdate
 import Services.feedback_service as feedback_service
 

--- a/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 
-from fastapi import APIRouter, HTTPException, Response, Depends
+from fastapi import APIRouter, HTTPException, Response, Depend, Query
 from Models.feedback_model import Feedback, VoteUpdate
 import Services.feedback_service as feedback_service
 

--- a/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/feedback_controller.py
@@ -45,3 +45,10 @@ def set_downvote(voteUpdate: VoteUpdate, response: Response, current_user: str =
         response.status_code = HTTPStatus.NOT_FOUND
         return json.loads(err_json)
     
+@router.get("/check", status_code=200)
+def check(voteUpdate: VoteUpdate, current_user: str = Depends(authentication_service.get_current_username)):
+    try:
+        response = feedback_service.check_feeedback(voteUpdate.entityType, voteUpdate.entityID, current_user)
+        return {"message": response}
+    except ValueError as err:
+        raise HTTPException(status_code = 500, detail="An error occured while checking the user feedback")

--- a/Disaster-Response-Platform/backend/Services/feedback_service.py
+++ b/Disaster-Response-Platform/backend/Services/feedback_service.py
@@ -53,3 +53,14 @@ def set_downvote(entity_type: EntityTypeEnum, entity_id: str, num: int) -> bool:
         raise ValueError(f"Entity type {entity_type.value} with entity id {entity_id} not found")
     return True
 
+
+# Check the feedback status of the current user, entity pair.
+def check_feeedback(entityType:str, entityID:str, current_user:str):
+    existing_vote = feedback_collection.find_one({"entityType": entityType, "entityID": entityID, "username": current_user})
+    if existing_vote:
+        if existing_vote['vote'] == "upvote":
+            return "upvote"
+        else:
+            return "downvote"
+    else:
+        return "none"


### PR DESCRIPTION
### Overview
This PR introduces a new endpoint to the feedback service that enables checking if the current user has given a feedback to a specific entity or not. Returns appropriate responses based on the case.

### Endpoint

**Check Feedback Status (`/api/feedback/check`)**
  - **Method**: GET
  - **Description**: Returns the feedback status of the current user with the specified entity.
  - **Parameters**: 
    - `entityType`: type of the entity. `needs` or `resources` or `actions` or `events`. Query parameter.
    - `entityID`: ID of the entity, like `658180928933f4830e026d2c`. Query parameter.
    - `Authentication` header token is also required to specify the user.
  - **Successfull Responses**:
    - HTTP 200: `{"message": "upvote"}` 
    - HTTP 200: `{"message": "downvote"}`
    - HTTP 200: `{"message": "none"}`
  - **Failure Response**:
    - HTTP 500: `{"detail": "An error occured while checking the user feedback"}` 
    - Missing auth header returns  HTTP 401: `{"detail": "Could not validate credentials"}`).
 - **Usage**: 
    - `/api/feedback/check?entityType=resources&entityID=658180928933f4830e026d2c`
    - `/api/feedback/check?entityType=needs&entityID=658180943433f4830e026d2c`
    - `/api/feedback/check?entityType=events&entityID=658180912333f4830e026d2c`
    - `/api/feedback/check?entityType=actions&entityID=658180912322f4830e026d2c`
 
