### PR TITLE
Adding only profile p URL is now possible. Fixed.

### DIFF
--- a/Disaster-Response-Platform/backend/Services/uprofile_optinfo_service.py
+++ b/Disaster-Response-Platform/backend/Services/uprofile_optinfo_service.py
@@ -26,7 +26,7 @@ def set_user_optional_info(user_optional_info: UserOptionalInfo) -> str:
 
     if not any([user_optional_info.Address,
                user_optional_info.education,
-               user_optional_info.blood_type,
+               user_optional_info.blood_type, user_optional_info.profile_picture,
                user_optional_info.date_of_birth, user_optional_info.health_condition, user_optional_info.identity_number,
                user_optional_info.nationality]):
         raise ValueError("No data supplied for optional info")


### PR DESCRIPTION
Hotfix. When setting optional info it is now ok if only profile picture URL is given.