### PR TITLE
Frontend - Fix main layout being too short

### DIFF
--- a/Disaster-Response-Platform/frontend/layouts/MainLayout.module.scss
+++ b/Disaster-Response-Platform/frontend/layouts/MainLayout.module.scss
@@ -11,8 +11,8 @@
     overflow-x: hidden;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    height: 100vh;
+    justify-content: flex-start;
+    min-height: 100vh;
 
     
 }
@@ -20,11 +20,11 @@
 .body {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
     align-items: center;
     background-color: $bg-color;
     color:#262626;
     padding: 2rem;
-    height:92%;
     // min-width: 600px;
 
 }


### PR DESCRIPTION
The white background of the page would cut off if the page was longer than the viewport and you scrolled down. This pull request fixes that.