### PR TITLE
added check for predefined need type(missing person)

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/form_fields.json
+++ b/Disaster-Response-Platform/backend/Controllers/form_fields.json
@@ -19,7 +19,7 @@
             {"name": "initialQuantity", "label": "Initial Quantity", "type": "number"},
             {"name": "quantityUnit", "label": "Unit", "type": "select", "options": ["kg", "piece", "portion", "daily", "lt", "gram", "box", "pack"]},
             {"name": "urgency", "label": "Urgency", "type": "select", "options": [1, 2, 3, 4, 5]},
-            {"name": "type", "label": "Type", "type": "select", "options": ["cloth", "food", "drink", "shelter", "medication", "transportation", "tool", "human", "other"]},
+            {"name": "type", "label": "Type", "type": "select", "options": ["cloth", "food", "drink", "shelter", "medication", "transportation", "tool", "human", "missing person", "other"]},
             {"name": "x", "label": "X Coordinate", "type": "number"},
             {"name": "y", "label": "Y Coordinate", "type": "number"},
             {"name": "occur_at", "label": "Occur At", "type": "date"},
@@ -107,6 +107,12 @@
                 {"name": "proficiency", "label": "Proficiency", "type": "text"},
                 {"name": "number_of_people", "label": "Number of People", "type": "number"},
                 {"name": "subtype", "label": "Subtype", "type": "select", "options": ["doctor", "engineer", "teacher", "laborer"]}
+            ]
+        },
+        "missing person": {
+            "fields": [
+                {"name": "missing_person_name", "label": "Missing Person Name Surname", "type": "text"},
+                {"name": "missing_person_location", "label": "Number of People", "type": "number"}
             ]
         }
     }

--- a/Disaster-Response-Platform/backend/Services/need_service.py
+++ b/Disaster-Response-Platform/backend/Services/need_service.py
@@ -24,14 +24,22 @@ r_id=0
 def create_need(need: Need) -> str:
     global r_id
     # Manual validation for required fields during creation
-    if not all([need.created_by, need.urgency, 
-                need.initialQuantity is not None, need.unsuppliedQuantity is not None, 
+    if not all([need.created_by, need.urgency,  
                 need.type, need.details, need.x is not None, need.y is not None]):
-        raise ValueError("All fields are mandatory for creation: created_by, urgency, initialQuantity, unsuppliedQuantity, type, details, x, y")
+        raise ValueError("All fields are mandatory for creation: created_by, urgency, type, details, x, y")
 
+    if need.type.lower() != "missing person" and not (need.initialQuantity is not None and need.unsuppliedQuantity is not None):
+        raise ValueError("Initial and unsupplied quantities are required for the need.")
+        
+    
     validate_coordinates(need.x, need.y)
     validate_quantities(need.initialQuantity, need.unsuppliedQuantity)
     
+    if need.type.lower() == "missing person" and need.details:
+        if not ('missing_person_name' in need.details and 'missing_person_location' in need.details):
+            raise ValueError("Missing person name and location are required for missing person needs.")
+    else:
+        raise ValueError("Missing person details(name and location) are required for missing person needs.")  
     insert_result = needs_collection.insert_one(need.dict())
     print("need added ", insert_result, need.occur_at)
 

--- a/Disaster-Response-Platform/backend/Services/need_service.py
+++ b/Disaster-Response-Platform/backend/Services/need_service.py
@@ -24,6 +24,25 @@ r_id=0
 def create_need(need: Need) -> str:
     global r_id
     # Manual validation for required fields during creation
+    
+        
+    if need.type.lower() == "missing person" and need.details:
+        if not ('missing_person_name' in need.details and 'missing_person_location' in need.details):
+            raise ValueError("Missing person name and location are required for missing person needs.")
+        else:
+            # cursor = needs_collection.find({
+            #     "$and": [
+            #         {"type": {"$regex": "missing person", "$options": "i"}},
+            #         {"details.missing_person_name": {"$regex": need.details['missing_person_name'], "$options": "i"}}
+            #     ]
+            # })
+            existing_need = needs_collection.find_one({"type": "missing person", "details.missing_person_name": {"$regex": need.details['missing_person_name'], "$options": "i"}})   
+            if existing_need:
+                raise ValueError("Emergency for this missing person exists " + existing_need["details"]["missing_person_name"])
+    else:
+        raise ValueError("Missing person details(name and location) are required for missing person needs.")  
+    
+
     if not all([need.created_by, need.urgency,  
                 need.type, need.details, need.x is not None, need.y is not None]):
         raise ValueError("All fields are mandatory for creation: created_by, urgency, type, details, x, y")
@@ -34,12 +53,7 @@ def create_need(need: Need) -> str:
     
     validate_coordinates(need.x, need.y)
     validate_quantities(need.initialQuantity, need.unsuppliedQuantity)
-    
-    if need.type.lower() == "missing person" and need.details:
-        if not ('missing_person_name' in need.details and 'missing_person_location' in need.details):
-            raise ValueError("Missing person name and location are required for missing person needs.")
-    else:
-        raise ValueError("Missing person details(name and location) are required for missing person needs.")  
+
     insert_result = needs_collection.insert_one(need.dict())
     print("need added ", insert_result, need.occur_at)
 


### PR DESCRIPTION
As stated in issue #742, necessary checks are added for missing person type. 
Following information should be provided:
{"type": "missing person",
"details": {
      "missing_person_name": "Jane Doe",
      "missing_person_location": "under rubble in Maras"
        }
....}
"initialQuantity" and "unsuppliedQuantity" shouldn't be provided, if "type" is "missing person"