### PR TITLE
Backend - fix report reject/accept

### DIFF
--- a/Disaster-Response-Platform/backend/Controllers/report_controller.py
+++ b/Disaster-Response-Platform/backend/Controllers/report_controller.py
@@ -96,7 +96,7 @@ def accept_report(report: AcceptReport, response:Response, current_user: UserPro
         response.status_code=HTTPStatus.OK
         # return json.loads(res)
         if not res:
-            raise ValueError(f"Report id {report_id} not rejected") 
+            raise ValueError(f"Report id {report.report_id} not accepted") 
         return f'Report {report.report_id} accepted'
     except ValueError as err:
         err_json = create_json_for_error("Report accept error", str(err))

--- a/Disaster-Response-Platform/backend/Services/report_service.py
+++ b/Disaster-Response-Platform/backend/Services/report_service.py
@@ -90,7 +90,7 @@ def reject_report(report_id: str):
     result = reports_collection.update_one({"_id": ObjectId(report_id)}, {"$set": {"status": "rejected"}})
     if result.matched_count == 0:
         raise ValueError(f"Report id {report_id} not found")
-    # return True
+    return True
 
 def accept_report(report_id: str, report_type:str, report_type_id: str) :
     result = reports_collection.update_one({"_id": ObjectId(report_id)}, {"$set": {"status": "accepted"}})
@@ -103,5 +103,6 @@ def accept_report(report_id: str, report_type:str, report_type_id: str) :
         if d.deleted_count == 0:
             raise ValueError(f"{report_type} {report_type_id} cannot be deleted")
     except:
-        raise ValueError(f"{report_type} {report_type_id} cannot be deleted")  
+        raise ValueError(f"{report_type} {report_type_id} cannot be deleted")
+    return True
 


### PR DESCRIPTION
This pull request fixes two minor problems in the report reject/accept services:
- The services not returning true even if they succeeded
- The typo 'report-id' instead of 'report.report-id' which makes the code invalid