### PR TITLE
Be/feature/reliability-score

### DIFF
--- a/Disaster-Response-Platform/backend/Services/event_service.py
+++ b/Disaster-Response-Platform/backend/Services/event_service.py
@@ -8,6 +8,7 @@ import Services.utilities
 
 from pymongo import ASCENDING, DESCENDING
 from typing import Optional
+import math
 
 # Get the resources collection using the MongoDB class
 events_collection = MongoDB.get_collection('events')
@@ -26,33 +27,35 @@ def create_event(event: Event) -> str:
         raise ValueError("Event could not be created")
 
 def get_event_by_id(event_id: str) -> list[dict]:
-    return get_events_X(event_id)
+    return get_events(event_id)
 
-def get_events(event_id:str = None, types: list = None,
+def get_events(event_id: str = None, types: list = None,
                is_active: Optional[bool] = None,
                x: float = None,
                y: float = None,
                distance_max: float = None,
                sort_by: str = 'created_at',
                order: Optional[str] = 'desc'
-               )  -> list[dict]:
-    projection = {"_id": {"$toString": "$_id"},
-                  "event_type": 1,
-                  "event_time": 1,
-                  "end_time": 1,
-                  "is_active":1,
-                  "x": 1,
-                  "y": 1,
-                  "max_distance_x": 1,
-                  "max_distance_y": 1,
-                  "created_time": 1,
-                  "created_by_user": 1,
-                  "last_confirmed_time": 1,
-                  "confirmed_by_user": 1,
-                  "short_description": 1,
-                  "downvote": 1,
-                  "upvote": 1,
-                  "note": 1
+               ) -> list[dict]:
+    projection = {
+        "_id": {"$toString": "$_id"},
+        "event_type": 1,
+        "event_time": 1,
+        "end_time": 1,
+        "is_active": 1,
+        "x": 1,
+        "y": 1,
+        "max_distance_x": 1,
+        "max_distance_y": 1,
+        "created_time": 1,
+        "created_by_user": 1,
+        "last_confirmed_time": 1,
+        "confirmed_by_user": 1,
+        "short_description": 1,
+        "downvote": 1,
+        "upvote": 1,
+        "reliability": 1,
+        "note": 1
     }
     sort_order = ASCENDING if order == 'asc' else DESCENDING
     query = {}
@@ -76,9 +79,27 @@ def get_events(event_id:str = None, types: list = None,
         # Filter by distance if necessary
         if x is not None and y is not None and distance_max is not None:
             events_data = [res for res in events_data if
-                              ((res['x'] - x) ** 2 + (res['y'] - y) ** 2) ** 0.5 <= distance_max]
+                           ((res['x'] - x) ** 2 + (res['y'] - y) ** 2) ** 0.5 <= distance_max]
 
-        # Format the resource data
+        for event in events_data:
+            upvotes = event.get('upvote', 0)
+            downvotes = event.get('downvote', 0)
+            total_votes = upvotes + downvotes
+
+            if total_votes > 0:
+                z = 1.96  # 95% confidence interval
+                phat = upvotes / total_votes
+                event['reliability'] = (
+                            phat + z ** 2 / (2 * total_votes) - z * math.sqrt(
+                        (phat * (1 - phat) + z ** 2 / (4 * total_votes)) / total_votes)) / (1 + z ** 2 / total_votes)
+            else:
+                event['reliability'] = 0.5  # Default score for no votes
+
+        # Calculate and sort by reliability score if requested
+        if sort_by == 'reliability':
+            events_data.sort(key=lambda x: x['reliability'], reverse=(order == 'desc'))
+
+        # Formatting datetime fields
         formatted_events_data = []
         for event in events_data:
             if 'created_time' in event:
@@ -93,44 +114,44 @@ def get_events(event_id:str = None, types: list = None,
         return result_list
 
 
-def get_events_X(event_id:str = None) -> list[dict]:
-    projection = {"_id": {"$toString": "$_id"},
-                  "event_type": 1,
-                  "event_time": 1,
-                  "end_time": 1,
-                  "is_active":1,
-                  "x": 1,
-                  "y": 1,
-                  "max_distance_x": 1,
-                  "max_distance_y": 1,
-                  "created_time": 1,
-                  "created_by_user": 1,
-                  "last_confirmed_time": 1,
-                  "confirmed_by_user": 1,
-                  "short_description": 1,
-                  "downvote": 1,
-                  "upvote": 1,
-                  "note": 1
-    }
+# def get_events_X(event_id:str = None) -> list[dict]:
+#     projection = {"_id": {"$toString": "$_id"},
+#                   "event_type": 1,
+#                   "event_time": 1,
+#                   "end_time": 1,
+#                   "is_active":1,
+#                   "x": 1,
+#                   "y": 1,
+#                   "max_distance_x": 1,
+#                   "max_distance_y": 1,
+#                   "created_time": 1,
+#                   "created_by_user": 1,
+#                   "last_confirmed_time": 1,
+#                   "confirmed_by_user": 1,
+#                   "short_description": 1,
+#                   "downvote": 1,
+#                   "upvote": 1,
+#                   "note": 1
+#     }
 
-    if (event_id is None):
-        query = {}
-    else:
-        if (ObjectId.is_valid(event_id)):
-            query = {"_id": ObjectId(event_id)}
-        else:
-            raise ValueError(f"Event id {event_id} is invalid")
+#     if (event_id is None):
+#         query = {}
+#     else:
+#         if (ObjectId.is_valid(event_id)):
+#             query = {"_id": ObjectId(event_id)}
+#         else:
+#             raise ValueError(f"Event id {event_id} is invalid")
 
-    events_data = events_collection.find(query, projection)
+#     events_data = events_collection.find(query, projection)
 
-    if (events_data.explain()["executionStats"]["nReturned"] == 0):
-        if event_id is None:
-            raise ValueError(f"No event exists")
-        else:
-            raise ValueError(f"Event {event_id} does not exist")
+#     if (events_data.explain()["executionStats"]["nReturned"] == 0):
+#         if event_id is None:
+#             raise ValueError(f"No event exists")
+#         else:
+#             raise ValueError(f"Event {event_id} does not exist")
 
-    result_list = create_json_for_successful_data_fetch(events_data, "events")
-    return result_list
+#     result_list = create_json_for_successful_data_fetch(events_data, "events")
+#     return result_list
     
 def update_event(event_id: str, event:Event) -> list[dict]:
     # Fetch the existing resource

--- a/Disaster-Response-Platform/backend/Services/need_service.py
+++ b/Disaster-Response-Platform/backend/Services/need_service.py
@@ -117,6 +117,7 @@ def get_needs(
         "last_updated_at": 1,
         "upvote": 1,
         "downvote": 1,
+        "reliability": 1,
         "open_address": 1
         # Add other fields if necessary
     }

--- a/Disaster-Response-Platform/backend/Services/resource_service.py
+++ b/Disaster-Response-Platform/backend/Services/resource_service.py
@@ -5,6 +5,7 @@ from pymongo import ASCENDING, DESCENDING
 from Services.build_API_returns import *
 from typing import Optional
 from datetime import datetime, timedelta
+import math
 
 # Get the resources collection using the MongoDB class
 resources_collection = MongoDB.get_collection('resources')
@@ -98,57 +99,77 @@ def get_resources(
     sort_by: str = 'created_at',
     order: Optional[str] = 'desc'
 ) -> list[dict]:
-    projection = {"_id": {"$toString": "$_id"},
-                  "created_by": 1,
-                  "description": 1,
-                  "condition": 1,
-                  "initialQuantity": 1,
-                  "currentQuantity": 1,
-                  "quantityUnit": 1,
-                  "type": 1,
-                  "details":1,
-                  "recurrence_id": 1,
-                  "recurrence_rate": 1,
-                  "recurrence_deadline": 1,
-                  "x":1,
-                  "y":1,
-                  "active": 1,
-                  "occur_at": 1,
-                  "created_at":1,
-                  "last_updated_at":1,
-                  "upvote":1,
-                  "downvote":1 ,
-                  "open_address":1
-                  }
+    projection = {
+        "_id": {"$toString": "$_id"},
+        "created_by": 1,
+        "description": 1,
+        "condition": 1,
+        "initialQuantity": 1,
+        "currentQuantity": 1,
+        "quantityUnit": 1,
+        "type": 1,
+        "details": 1,
+        "recurrence_id": 1,
+        "recurrence_rate": 1,
+        "recurrence_deadline": 1,
+        "x": 1,
+        "y": 1,
+        "active": 1,
+        "occur_at": 1,
+        "created_at": 1,
+        "last_updated_at": 1,
+        "upvote": 1,
+        "downvote": 1,
+        "reliability": 1,
+        "open_address": 1
+    }
     
     sort_order = ASCENDING if order == 'asc' else DESCENDING
     query = {}
     
+    # Apply filters based on resource_id, active status, types, and subtypes
     if resource_id:
-        
         if ObjectId.is_valid(resource_id):
-            
             query['_id'] = ObjectId(resource_id)
         else:
             raise ValueError(f"Resource id {resource_id} is invalid")
     else:
-        # Apply general filters only when no specific resource ID is provided
-        
         if active is not None:
             query['active'] = active    
         if types:
             query['type'] = {'$in': types}
         if subtypes:
             query['details.subtype'] = {'$in': subtypes}
-    
-    # Apply the query and sort order to the database call
-    resources_cursor = resources_collection.find(query, projection).sort(sort_by, sort_order)
+
+    # Fetch the resources from the database
+    resources_cursor = resources_collection.find(query, projection)
+
+    # Sort in the database only if the sort criteria is not 'reliability_score'
+    if sort_by != 'reliability':
+        resources_cursor = resources_cursor.sort(sort_by, sort_order)
+
     resources_data = list(resources_cursor)  # Convert cursor to list
 
     # Filter by distance if necessary
     if x is not None and y is not None and distance_max is not None:
         resources_data = [res for res in resources_data if ((res['x'] - x) ** 2 + (res['y'] - y) ** 2) ** 0.5 <= distance_max]
-    
+
+    for resource in resources_data:
+        upvotes = resource.get('upvote', 0)
+        downvotes = resource.get('downvote', 0)
+        total_votes = upvotes + downvotes
+
+        if total_votes > 0:
+            z = 1.96  # 95% confidence interval
+            phat = upvotes / total_votes
+            resource['reliability'] = (phat + z**2 / (2 * total_votes) - z * math.sqrt((phat * (1 - phat) + z**2 / (4 * total_votes)) / total_votes)) / (1 + z**2 / total_votes)
+        else:
+            resource['reliability'] = 0.5  # Default score for no votes
+
+    # Calculate and sort by reliability score if requested
+    if sort_by == 'reliability':
+        resources_data.sort(key=lambda x: x['reliability'], reverse=(order == 'desc'))
+
     # Format the resource data
     formatted_resources_data = []
     for resource in resources_data:


### PR DESCRIPTION
### Overview
This PR adds a `reliability` field to the _get all_ method responses of `resources`, `needs`, and `events`. The reliability score is calculated based on the upvotes and downvotes for each item. It is used to assess the credibility and trustworthiness of the information provided by users.

### Reliability Score Calculation
The reliability score is calculated using the Wilson Score Interval, a statistical method that takes into account the proportion of upvotes to total votes while considering the %95 confidence interval.  The formula is: 

```
z = 1.96  # 95% confidence interval
phat = upvotes / total_votes
reliability = (phat + z^2 / (2 * total_votes) - z * sqrt((phat * (1 - phat) + z^2 / (4 * total_votes)) / total_votes)) / (1 + z^2 / total_votes)
```

- `upvotes`: The number of upvotes for the item.
- `downvotes`: The number of downvotes for the item.
- `total_votes`: The total number of votes (upvotes + downvotes).

The reliability score ranges from 0 to 1, with higher values indicating higher reliability. Items with more upvotes and a higher proportion of upvotes to total votes will have a higher reliability score, reflecting greater trustworthiness.

### Sorting
To sort by reliability, simply add `sort_by=reliability&order=desc` or `sort_by=reliability&order=asc` to the query.
